### PR TITLE
Eliminate multiple GC.Alloc caused by Enum.Equals

### DIFF
--- a/Assets/SpriteAnimations/Editor/Scripts/Windows/AnimationsExtractor.cs
+++ b/Assets/SpriteAnimations/Editor/Scripts/Windows/AnimationsExtractor.cs
@@ -149,7 +149,7 @@ namespace SpriteAnimations.Editor
             string unityFolderPath = Path.GetDirectoryName(assetPath);
             string projectRootPath = Path.GetFullPath(Path.Combine(Application.dataPath, @"..\"));
 
-            if (orientation.Equals(ExtractionOrientation.Horizontal))
+            if (orientation == ExtractionOrientation.Horizontal)
             {
                 if (!HorizontalExtraction(originalSprite, from, amount, numberOfAnimations, unityFolderPath, projectRootPath))
                 {
@@ -415,8 +415,8 @@ namespace SpriteAnimations.Editor
 
         private void SetOrientation(ExtractionOrientation orientation)
         {
-            _columnsField.style.display = orientation.Equals(ExtractionOrientation.Horizontal) ? DisplayStyle.Flex : DisplayStyle.None;
-            _rowsField.style.display = orientation.Equals(ExtractionOrientation.Vertical) ? DisplayStyle.Flex : DisplayStyle.None;
+            _columnsField.style.display = orientation == ExtractionOrientation.Horizontal ? DisplayStyle.Flex : DisplayStyle.None;
+            _rowsField.style.display = orientation == ExtractionOrientation.Vertical ? DisplayStyle.Flex : DisplayStyle.None;
         }
 
         #endregion

--- a/Assets/SpriteAnimations/Editor/Scripts/Windows/AnimationsManagerWindow.cs
+++ b/Assets/SpriteAnimations/Editor/Scripts/Windows/AnimationsManagerWindow.cs
@@ -157,7 +157,7 @@ namespace SpriteAnimations.Editor
 
         private void OnPlayModeStateChanged(PlayModeStateChange change)
         {
-            if (!change.Equals(PlayModeStateChange.EnteredEditMode)) return;
+            if (change != PlayModeStateChange.EnteredEditMode) return;
             LoadAnimatorFromData();
         }
 

--- a/Assets/SpriteAnimations/Runtime/Scripts/Performers/CompositeAnimator.cs
+++ b/Assets/SpriteAnimations/Runtime/Scripts/Performers/CompositeAnimator.cs
@@ -144,7 +144,7 @@ namespace SpriteAnimations
             ResetCycle();
 
             // Check if the current cycle is Antecipation
-            if (_currentCompositeCycle.Equals(CompositeCycle.Antecipation))
+            if (_currentCompositeCycle == CompositeCycle.Antecipation)
             {
                 // Change the cycle to Core
                 ChangeCycle(CompositeCycle.Core);
@@ -155,7 +155,7 @@ namespace SpriteAnimations
             }
 
             // Check if the current cycle is Core
-            if (_currentCompositeCycle.Equals(CompositeCycle.Core))
+            if (_currentCompositeCycle == CompositeCycle.Core)
             {
                 // Check if the Core cycle is not loopable
                 if (!_shouldLoopCore)

--- a/Assets/SpriteAnimations/Runtime/Scripts/Performers/WindroseAnimator.cs
+++ b/Assets/SpriteAnimations/Runtime/Scripts/Performers/WindroseAnimator.cs
@@ -148,7 +148,7 @@ namespace SpriteAnimations
                 return this;
             }
 
-            if (flipStrategy.Equals(WindroseFlipStrategy.FlipEastToPlayWest))
+            if (flipStrategy == WindroseFlipStrategy.FlipEastToPlayWest)
             {
                 bool shouldFlip = false;
                 switch (direction)

--- a/Assets/SpriteAnimations/Runtime/Scripts/SpriteAnimator.cs
+++ b/Assets/SpriteAnimations/Runtime/Scripts/SpriteAnimator.cs
@@ -158,19 +158,19 @@ namespace SpriteAnimations
 
         protected virtual void Update()
         {
-            if (!IsPlaying || !_updateMode.Equals(UpdateMode.Update)) return;
+            if (!IsPlaying || _updateMode != UpdateMode.Update) return;
             _currentPerformer?.Tick(Time.deltaTime);
         }
 
         protected virtual void LateUpdate()
         {
-            if (!IsPlaying || !_updateMode.Equals(UpdateMode.LateUpdate)) return;
+            if (!IsPlaying || _updateMode != UpdateMode.LateUpdate) return;
             _currentPerformer?.Tick(Time.deltaTime);
         }
 
         protected virtual void FixedUpdate()
         {
-            if (!IsPlaying || !_updateMode.Equals(UpdateMode.FixedUpdate)) return;
+            if (!IsPlaying || _updateMode != UpdateMode.FixedUpdate) return;
             _currentPerformer?.Tick(Time.deltaTime);
         }
 


### PR DESCRIPTION
Use equality operators instead because Enum.Equals will box the value.